### PR TITLE
Fix verify_ssl handling

### DIFF
--- a/custom_components/wibutler/api.py
+++ b/custom_components/wibutler/api.py
@@ -2,6 +2,7 @@ import aiohttp
 import asyncio
 import json
 import logging
+import ssl
 from typing import Any, Dict, Optional, List, Callable
 from urllib.parse import urlparse
 
@@ -9,10 +10,20 @@ from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class WibutlerHub:
     """Verwaltet die Kommunikation mit der Wibutler API, inklusive WebSockets."""
 
-    def __init__(self, hass: HomeAssistant, host: str, port: int, username: str, password: str, verify_ssl: bool = False, use_ssl: bool = False):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        host: str,
+        port: int,
+        username: str,
+        password: str,
+        verify_ssl: bool = False,
+        use_ssl: bool = False,
+    ):
         """Initialisiere Wibutler API-Verbindung."""
         self.hass = hass
         self.host = host
@@ -21,28 +32,38 @@ class WibutlerHub:
         self.use_ssl = use_ssl
         self.username = username
         self.password = password
-        self.session = aiohttp.ClientSession()
+
         self.token: Optional[str] = None
         self.ws_task: Optional[asyncio.Task] = None
         self.listeners: List[Callable[[str, Any], None]] = []
 
-        if self.use_ssl:
-            self.schema = "https"
-        else:
-            self.schema = "http"
+        # Schema festlegen
+        self.schema = "https" if self.use_ssl else "http"
 
-        # check if host has a scheme, if so set the baseUrl to the host without the scheme
-        if urlparse(self.host).scheme:
-            self.baseUrl = urlparse(self.host).hostname
+        # Host normalisieren (falls host mit http(s):// übergeben wird)
+        parsed = urlparse(self.host)
+        if parsed.scheme:
+            # z.B. https://192.168.178.66 -> hostname extrahieren
+            self.baseUrl = parsed.hostname or self.host
         else:
             self.baseUrl = self.host
 
-        if self.verify_ssl is False:
-            _LOGGER.debug("🔓 SSL-Überprüfung ist deaktiviert (verify_ssl=False).")
-            connector = aiohttp.TCPConnector(ssl=False)  # Deaktiviere SSL-Überprüfung
+        # SSL-Kontext / Connector korrekt erstellen und in die Session einhängen
+        if self.use_ssl:
+            if self.verify_ssl:
+                _LOGGER.debug("🔒 SSL-Überprüfung ist aktiviert (verify_ssl=True).")
+                ssl_context = ssl.create_default_context()
+            else:
+                _LOGGER.debug("🔓 SSL-Überprüfung ist deaktiviert (verify_ssl=False).")
+                ssl_context = ssl._create_unverified_context()
+
+            connector = aiohttp.TCPConnector(ssl=ssl_context)
         else:
-            _LOGGER.debug("🔒 SSL-Überprüfung ist aktiviert (verify_ssl=True).")
-            connector = aiohttp.TCPConnector(ssl=True)  # Aktiviere SSL-Überprüfung
+            # Kein TLS -> normaler Connector
+            connector = aiohttp.TCPConnector()
+
+        # WICHTIG: Session mit Connector erstellen (sonst wirkt verify_ssl nie!)
+        self.session = aiohttp.ClientSession(connector=connector)
 
     async def authenticate(self) -> bool:
         """Authentifiziert sich bei der Wibutler API und speichert das Token."""
@@ -59,13 +80,23 @@ class WibutlerHub:
                         return False
                     _LOGGER.info("✅ Erfolgreich authentifiziert!")
                     return True
-                else:
-                    _LOGGER.error("❌ Authentifizierung fehlgeschlagen: %s", await response.text())
+
+                _LOGGER.error(
+                    "❌ Authentifizierung fehlgeschlagen (%s): %s",
+                    response.status,
+                    await response.text(),
+                )
         except aiohttp.ClientError as err:
             _LOGGER.error("❌ Verbindungsfehler mit Wibutler API: %s", err)
+
         return False
 
-    async def _request(self, method: str, endpoint: str, data: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
         """Sendet eine Anfrage an die Wibutler API."""
         if not self.token:
             _LOGGER.warning("Kein Token vorhanden, erneute Authentifizierung erforderlich.")
@@ -78,15 +109,26 @@ class WibutlerHub:
         try:
             async with self.session.request(method, url, headers=headers, json=data) as response:
                 if response.status in (200, 201):
-                    return await response.json()
-                elif response.status == 401:
+                    # Manche Endpoints liefern evtl. kein JSON -> absichern
+                    ctype = response.headers.get("Content-Type", "")
+                    if "application/json" in ctype:
+                        return await response.json()
+                    text = await response.text()
+                    return {"raw": text}
+
+                if response.status == 401:
                     _LOGGER.warning("Token abgelaufen, erneute Authentifizierung erforderlich.")
                     self.token = None
                     return await self._request(method, endpoint, data)
-                else:
-                    _LOGGER.error("Fehlerhafte API-Antwort (%s): %s", response.status, await response.text())
+
+                _LOGGER.error(
+                    "Fehlerhafte API-Antwort (%s): %s",
+                    response.status,
+                    await response.text(),
+                )
         except aiohttp.ClientError as err:
             _LOGGER.error("Fehler bei der API-Anfrage: %s", err)
+
         return None
 
     async def get_devices(self) -> Optional[Dict[str, Any]]:
@@ -104,11 +146,19 @@ class WibutlerHub:
             return
 
         ws_protocol = "wss" if self.schema == "https" else "ws"
-        ws_url = f"{ws_protocol}://{self.host}:{self.port}/api/stream/{self.token}"
+        ws_url = f"{ws_protocol}://{self.baseUrl}:{self.port}/api/stream/{self.token}"
         _LOGGER.info("🔌 Verbindung zu WebSocket: %s", ws_url)
 
+        # Optional: explizite SSL-Option für ws_connect (zusätzlich zum Session-Connector)
+        ws_ssl = None
+        if self.schema == "https":
+            if self.verify_ssl:
+                ws_ssl = ssl.create_default_context()
+            else:
+                ws_ssl = ssl._create_unverified_context()
+
         try:
-            async with self.session.ws_connect(ws_url) as ws:
+            async with self.session.ws_connect(ws_url, ssl=ws_ssl) as ws:
                 async for msg in ws:
                     if msg.type == aiohttp.WSMsgType.TEXT:
                         try:
@@ -118,13 +168,17 @@ class WibutlerHub:
                                 self._handle_ws_message(device_id, data["data"]["components"])
                         except json.JSONDecodeError:
                             _LOGGER.error("❌ Fehler beim Parsen der WebSocket-Nachricht: %s", msg.data)
+                    elif msg.type == aiohttp.WSMsgType.ERROR:
+                        _LOGGER.error("❌ WebSocket-Fehler: %s", ws.exception())
+                        break
         except aiohttp.ClientError as err:
             _LOGGER.error("❌ WebSocket-Verbindungsfehler: %s", err)
 
     def _handle_ws_message(self, device_id: str, components: List[Dict[str, Any]]):
         """Verarbeitet WebSocket-Nachrichten und benachrichtigt nur relevante Entitäten."""
         for listener in self.listeners:
-            if listener._device_id == device_id:  # Nur relevante Entitäten aufrufen
+            # Nur relevante Entitäten aufrufen (wie bei dir)
+            if getattr(listener, "_device_id", None) == device_id:
                 listener.handle_ws_update(device_id, components)
 
     def register_listener(self, entity):


### PR DESCRIPTION
Hi,
while testing the integration with a wibutler pro 2 I noticed that the verify_ssl option has no effect. Even when it is set to false in the config flow, HTTPS connections still fail with SSLCertVerificationError: CERTIFICATE_VERIFY_FAILED.

The reason is in api.py: a aiohttp.TCPConnector is created depending on verify_ssl, but the ClientSession is already initialized earlier without a connector:

self.session = aiohttp.ClientSession()


As a result, the later connector is never used and SSL certificate verification always stays enabled.

This PR changes the code so that the ClientSession is created with the configured connector, for example:

import ssl

if self.use_ssl:
    if self.verify_ssl:
        ssl_context = ssl.create_default_context()
    else:
        ssl_context = ssl._create_unverified_context()
    connector = aiohttp.TCPConnector(ssl=ssl_context)
else:
    connector = aiohttp.TCPConnector()

self.session = aiohttp.ClientSession(connector=connector)


With this change, verify_ssl behaves as expected. The same SSL context is also applied to the WebSocket connection so that REST API and WebSocket behave consistently.

During debugging it also turned out that on the wibutler pro 2 the previously used port 8091 is no longer open. The local API is reachable via port 8081 instead. Using port 8081, HTTPS and verify_ssl = false works reliably after this change.

Tested with a wibutler pro 2, HTTPS with a self-signed certificate, use_ssl = true and verify_ssl = false.