### PR TITLE
Add rocker button events and controller with options flow

### DIFF
--- a/custom_components/wibutler/__init__.py
+++ b/custom_components/wibutler/__init__.py
@@ -1,24 +1,49 @@
-import asyncio
+"""Wibutler integration for Home Assistant."""
+
 import logging
-from typing import Any, Dict, Optional
-from homeassistant.core import HomeAssistant
+
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.typing import ConfigType
-from .const import DOMAIN, PLATFORMS  # Hier wird DOMAIN aus const.py importiert
+from homeassistant.core import HomeAssistant
+
 from .api import WibutlerHub
+from .const import PLATFORMS
+from .rocker import RockerController
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Setze die Konfigurationsdatei ein (configuration.yaml)."""
-    _LOGGER.debug("🔄 async_setup() in __init__.py wurde aufgerufen!")
-    hass.data.setdefault(DOMAIN, {})
-    return True
+type WibutlerConfigEntry = ConfigEntry[WibutlerHub]
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Setze die Konfiguration über die UI ein."""
-    _LOGGER.debug("🚀 async_setup_entry() wurde aufgerufen! Registriere Plattformen...")
+ROCKER_CONTROLLER_KEY = "rocker_controller"
 
+
+def _setup_rocker_controller(
+    hass: HomeAssistant, entry: WibutlerConfigEntry
+) -> None:
+    """Create and start rocker controller if bindings exist."""
+    options = entry.options or {}
+    bindings = options.get("rocker_bindings", [])
+
+    old_controller = getattr(entry, "rocker_controller", None)
+    if old_controller:
+        old_controller.stop()
+        entry.rocker_controller = None
+
+    if bindings:
+        dim_duration = options.get("dim_duration", 5.0)
+        controller = RockerController(hass, bindings, dim_duration=dim_duration)
+        controller.start()
+        entry.rocker_controller = controller
+
+
+async def _async_options_updated(
+    hass: HomeAssistant, entry: WibutlerConfigEntry
+) -> None:
+    """Handle options update - recreate rocker controller."""
+    _setup_rocker_controller(hass, entry)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: WibutlerConfigEntry) -> bool:
+    """Set up Wibutler from a config entry."""
     hub = WibutlerHub(
         hass,
         entry.data["host"],
@@ -30,27 +55,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     if not await hub.authenticate():
-        _LOGGER.error("❌ Authentifizierung fehlgeschlagen!")
+        _LOGGER.error("Authentication failed")
         return False
 
-    hass.data[DOMAIN]["hub"] = hub
-
-    _LOGGER.debug("📝 API Response (Authentifizierung): %s", hub.token)
-
     hub.devices = await hub.get_devices()
+    entry.runtime_data = hub
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    entry.async_create_background_task(
+        hass, hub.connect_websocket(), "wibutler_websocket"
     )
-    _LOGGER.debug("✅ Plattformen erfolgreich registriert!")
-    hass.loop.create_task(hub.connect_websocket())
+
+    _setup_rocker_controller(hass, entry)
+    entry.async_on_unload(
+        entry.add_update_listener(_async_options_updated)
+    )
 
     return True
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Entferne eine Konfiguration."""
-    _LOGGER.debug("🔄 async_unload_entry() wurde aufgerufen!")
+
+async def async_unload_entry(hass: HomeAssistant, entry: WibutlerConfigEntry) -> bool:
+    """Unload a config entry."""
+    controller = getattr(entry, "rocker_controller", None)
+    if controller:
+        controller.stop()
+        entry.rocker_controller = None
+
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id, None)
+        await entry.runtime_data.close()
     return unload_ok

--- a/custom_components/wibutler/binary_sensor.py
+++ b/custom_components/wibutler/binary_sensor.py
@@ -1,17 +1,21 @@
 """Binary sensor platform for Wibutler integration."""
 
 import logging
+import time
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 
 from . import WibutlerConfigEntry
+from .const import EVENT_WIBUTLER_BUTTON
 from .entity import WibutlerEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
+LONG_PRESS_THRESHOLD = 0.4
 
 BUTTON_MAPPING = {
     "SWT": ["BTN_0", "BTN_1"],
@@ -53,11 +57,70 @@ class WibutlerBinarySensor(WibutlerEntity, BinarySensorEntity):
         self._attr_name = f"{device['name']} - {component.get('text', self._original_name)}"
         self._attr_unique_id = f"{device['id']}_{self._original_name}"
         self._attr_is_on = False
+        self._press_time: float | None = None
+        self._long_press_timer = None
+        self._long_press_fired = False
 
     @property
     def is_on(self) -> bool:
         """Return true if the button is pressed."""
         return self._attr_is_on
+
+    def _build_event_data(self, action: str) -> dict:
+        """Build event data for a button action."""
+        return {
+            "device_id": self._device_id,
+            "device_name": self._device.get("name", ""),
+            "button": self._original_name,
+            "action": action,
+        }
+
+    @callback
+    def _fire_event(self, action: str) -> None:
+        """Fire a wibutler_button event (must be called from event loop)."""
+        self._hub.hass.bus.async_fire(
+            EVENT_WIBUTLER_BUTTON, self._build_event_data(action)
+        )
+
+    @callback
+    def _on_long_press_timer(self, _now) -> None:
+        """Handle long press timer expiry."""
+        self._long_press_fired = True
+        self._long_press_timer = None
+        self._fire_event("long_press_start")
+
+    @callback
+    def _handle_press(self) -> None:
+        """Handle button press in event loop."""
+        self._press_time = time.monotonic()
+        self._long_press_fired = False
+        self._fire_event("press")
+        if self._long_press_timer is not None:
+            self._long_press_timer()
+        self._long_press_timer = async_call_later(
+            self._hub.hass,
+            LONG_PRESS_THRESHOLD,
+            self._on_long_press_timer,
+        )
+
+    @callback
+    def _handle_release(self) -> None:
+        """Handle button release in event loop."""
+        if self._long_press_timer is not None:
+            self._long_press_timer()
+            self._long_press_timer = None
+        if self._long_press_fired:
+            self._fire_event("long_press_release")
+        else:
+            self._fire_event("short_press")
+        self._fire_event("release")
+        self._press_time = None
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Clean up timer on removal."""
+        if self._long_press_timer is not None:
+            self._long_press_timer()
+            self._long_press_timer = None
 
     def _fetch_state(self, components) -> None:
         """Update state from device data."""
@@ -86,5 +149,13 @@ class WibutlerBinarySensor(WibutlerEntity, BinarySensorEntity):
                     else f"BTN_B{button_index}"
                 )
 
-            if expected_btn == self._original_name:
-                self._attr_is_on = button_state == "D"
+            if expected_btn != self._original_name:
+                continue
+
+            was_on = self._attr_is_on
+            self._attr_is_on = button_state == "D"
+
+            if button_state == "D" and not was_on:
+                self._hub.hass.loop.call_soon_threadsafe(self._handle_press)
+            elif button_state == "U" and was_on:
+                self._hub.hass.loop.call_soon_threadsafe(self._handle_release)

--- a/custom_components/wibutler/config_flow.py
+++ b/custom_components/wibutler/config_flow.py
@@ -1,14 +1,27 @@
-"""Config flow für die Wibutler Integration."""
+"""Config flow for the Wibutler integration."""
+
 import logging
+
+import aiohttp
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.core import callback
-from .const import DOMAIN, CONF_HOST, CONF_PORT, CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL, CONF_USE_SSL
+from homeassistant.helpers.selector import EntitySelector, EntitySelectorConfig
+
+from .api import WibutlerHub
+from .const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USE_SSL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-# Definition des Eingabeformulars für die Erstkonfiguration
 DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
@@ -20,56 +33,223 @@ DATA_SCHEMA = vol.Schema(
     }
 )
 
+ROCKER_MODES = {
+    "dim_up": "Dim Up",
+    "dim_down": "Dim Down",
+    "cover_open": "Cover Open",
+    "cover_close": "Cover Close",
+    "toggle": "Toggle",
+    "turn_on": "Turn On",
+    "turn_off": "Turn Off",
+}
+
 
 class WibutlerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle die Konfigurations-UI für Wibutler."""
+    """Handle the config flow for Wibutler."""
 
     VERSION = 1
 
     async def async_step_user(self, user_input=None):
-        """Erster Schritt der Konfiguration."""
-        if user_input is None:
-            return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
+        """Handle the initial step."""
+        errors = {}
 
-        _LOGGER.debug(f"🎛️ Wibutler wird mit {user_input} konfiguriert")
+        if user_input is not None:
+            hub = WibutlerHub(
+                self.hass,
+                user_input[CONF_HOST],
+                user_input.get(CONF_PORT, 8081),
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASSWORD],
+                user_input.get(CONF_VERIFY_SSL, False),
+                user_input.get(CONF_USE_SSL, False),
+            )
 
-        return self.async_create_entry(title="Wibutler", data=user_input)
+            try:
+                if await hub.authenticate():
+                    await self.async_set_unique_id(user_input[CONF_HOST])
+                    self._abort_if_unique_id_configured()
+                    return self.async_create_entry(
+                        title="Wibutler", data=user_input
+                    )
+                errors["base"] = "invalid_auth"
+            except aiohttp.ClientError:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected error during config flow")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
 
     @staticmethod
     @callback
-    def async_get_options_flow(entry):
-        """Optionen für die Konfiguration bereitstellen."""
-        return WibutlerOptionsFlowHandler(entry)
+    def async_get_options_flow(config_entry):
+        """Get the options flow handler."""
+        return WibutlerOptionsFlowHandler()
 
 
 class WibutlerOptionsFlowHandler(config_entries.OptionsFlow):
-    """Optionen für die Wibutler Integration."""
-
-    def __init__(self, entry):
-        """Speichere die aktuelle Konfiguration."""
-        self.entry = entry
+    """Handle Wibutler options."""
 
     async def async_step_init(self, user_input=None):
-        """Zeige die Optionen an und erlaube Änderungen."""
+        """Show main options menu."""
         if user_input is not None:
-            _LOGGER.debug(f"🔄 Neue Wibutler-Konfiguration: {user_input}")
+            next_step = user_input.get("next_step")
+            if next_step == "rocker_menu":
+                return await self.async_step_rocker_menu()
+            return await self.async_step_connection()
 
-            # Erstelle den neuen Eintrag mit den aktualisierten Werten
-            return self.async_create_entry(title="", data=user_input)
-
-        # Aktuelle Werte abrufen
-        current_options = self.entry.options if self.entry.options else self.entry.data
-
-        # Formular mit aktuellen Werten als Standardwerte
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_HOST, default=current_options.get(CONF_HOST, "")): str,
-                vol.Required(CONF_PORT, default=current_options.get(CONF_PORT, 8081)): int,
-                vol.Required(CONF_PASSWORD, default=current_options.get(CONF_PASSWORD, "")): str,
-                vol.Required(CONF_USERNAME, default=current_options.get(CONF_USERNAME, "")): str,
-                vol.Required(CONF_VERIFY_SSL, default=current_options.get(CONF_VERIFY_SSL, False)): bool,
-                vol.Required(CONF_USE_SSL, default=current_options.get(CONF_USE_SSL, False)): bool,
+                vol.Required("next_step", default="connection"): vol.In(
+                    {
+                        "connection": "Connection Settings",
+                        "rocker_menu": "Rocker Bindings",
+                    }
+                ),
             }
         )
 
         return self.async_show_form(step_id="init", data_schema=data_schema)
+
+    async def async_step_connection(self, user_input=None):
+        """Manage connection settings."""
+        if user_input is not None:
+            data = dict(self.config_entry.options)
+            data.update(user_input)
+            return self.async_create_entry(title="", data=data)
+
+        current = self.config_entry.options or self.config_entry.data
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_HOST, default=current.get(CONF_HOST, "")
+                ): str,
+                vol.Required(
+                    CONF_PORT, default=current.get(CONF_PORT, 8081)
+                ): int,
+                vol.Required(
+                    CONF_USERNAME, default=current.get(CONF_USERNAME, "")
+                ): str,
+                vol.Required(
+                    CONF_PASSWORD, default=current.get(CONF_PASSWORD, "")
+                ): str,
+                vol.Required(
+                    CONF_VERIFY_SSL,
+                    default=current.get(CONF_VERIFY_SSL, False),
+                ): bool,
+                vol.Required(
+                    CONF_USE_SSL,
+                    default=current.get(CONF_USE_SSL, False),
+                ): bool,
+            }
+        )
+
+        return self.async_show_form(step_id="connection", data_schema=data_schema)
+
+    async def async_step_rocker_menu(self, user_input=None):
+        """Show existing bindings and option to add/remove."""
+        bindings = list(
+            self.config_entry.options.get("rocker_bindings", [])
+        )
+
+        if user_input is not None:
+            dim_duration = user_input.get("dim_duration", 5.0)
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                options={**self.config_entry.options, "dim_duration": dim_duration},
+            )
+
+            action = user_input.get("action")
+            if action == "add":
+                return await self.async_step_add_binding()
+            if action and action.startswith("remove_"):
+                idx = int(action.split("_", 1)[1])
+                bindings.pop(idx)
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    options={**self.config_entry.options, "rocker_bindings": bindings},
+                )
+                return await self.async_step_rocker_menu()
+
+        current_duration = self.config_entry.options.get("dim_duration", 5.0)
+
+        actions = {"add": "Add Binding"}
+        for i, b in enumerate(bindings):
+            entities = b.get("target_entity_ids", [b["target_entity_id"]] if "target_entity_id" in b else [])
+            label = f"{b.get('device_name', b['device_id'])} {b['button']} -> {', '.join(entities)} ({b['mode']})"
+            actions[f"remove_{i}"] = f"Remove: {label}"
+
+        data_schema = vol.Schema(
+            {
+                vol.Required("dim_duration", default=current_duration): vol.All(
+                    vol.Coerce(float), vol.Range(min=1.0, max=30.0)
+                ),
+                vol.Required("action"): vol.In(actions),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="rocker_menu",
+            data_schema=data_schema,
+        )
+
+    async def async_step_add_binding(self, user_input=None):
+        """Add a new rocker binding."""
+        if user_input is not None:
+            bindings = list(
+                self.config_entry.options.get("rocker_bindings", [])
+            )
+
+            hub = self.config_entry.runtime_data
+            device = hub.devices.get(user_input["device_button"].split("|")[0], {})
+
+            bindings.append(
+                {
+                    "device_id": user_input["device_button"].split("|")[0],
+                    "device_name": device.get("name", ""),
+                    "button": user_input["device_button"].split("|")[1],
+                    "target_entity_ids": user_input["target_entity_ids"],
+                    "mode": user_input["mode"],
+                }
+            )
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                options={**self.config_entry.options, "rocker_bindings": bindings},
+            )
+            return await self.async_step_rocker_menu()
+
+        hub = self.config_entry.runtime_data
+        bindings = self.config_entry.options.get("rocker_bindings", [])
+        bound_keys = {f"{b['device_id']}|{b['button']}" for b in bindings}
+
+        button_options = {}
+        for device_id, device in hub.devices.items():
+            for comp in device.get("components", []):
+                name = comp.get("name", "")
+                if name.startswith("BTN"):
+                    key = f"{device_id}|{name}"
+                    if key in bound_keys:
+                        continue
+                    label = f"{device.get('name', device_id)} - {comp.get('text', name)}"
+                    button_options[key] = label
+
+        if not button_options:
+            return await self.async_step_rocker_menu()
+
+        data_schema = vol.Schema(
+            {
+                vol.Required("device_button"): vol.In(button_options),
+                vol.Required("target_entity_ids"): EntitySelector(
+                    EntitySelectorConfig(multiple=True)
+                ),
+                vol.Required("mode"): vol.In(ROCKER_MODES),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="add_binding",
+            data_schema=data_schema,
+        )

--- a/custom_components/wibutler/const.py
+++ b/custom_components/wibutler/const.py
@@ -1,6 +1,9 @@
-"""Konstanten für die Wibutler Integration."""
+"""Constants for the Wibutler integration."""
+
+from homeassistant.const import Platform
 
 DOMAIN = "wibutler"
+EVENT_WIBUTLER_BUTTON = "wibutler_button"
 
 CONF_HOST = "host"
 CONF_PORT = "port"
@@ -9,4 +12,11 @@ CONF_PASSWORD = "password"
 CONF_VERIFY_SSL = "verify_ssl"
 CONF_USE_SSL = "use_ssl"
 
-PLATFORMS = ["sensor", "climate", "cover", "switch", "binary_sensor", "light"]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.CLIMATE,
+    Platform.COVER,
+    Platform.LIGHT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]

--- a/custom_components/wibutler/rocker.py
+++ b/custom_components/wibutler/rocker.py
@@ -1,0 +1,159 @@
+"""Rocker controller for Wibutler button-to-entity bindings."""
+
+import asyncio
+import logging
+
+from homeassistant.core import Event, HomeAssistant
+
+from .const import EVENT_WIBUTLER_BUTTON
+
+_LOGGER = logging.getLogger(__name__)
+
+DIM_INTERVAL = 0.2
+DEFAULT_DIM_DURATION = 5.0
+
+
+class RockerController:
+    """Consumes wibutler_button events and controls bound entities."""
+
+    def __init__(
+        self, hass: HomeAssistant, bindings: list[dict], dim_duration: float = DEFAULT_DIM_DURATION
+    ) -> None:
+        """Initialize with a list of bindings."""
+        self._hass = hass
+        self._bindings = bindings
+        self._dim_step = max(1, round(255 / (dim_duration / DIM_INTERVAL)))
+        self._unsub = None
+        self._active_tasks: dict[str, asyncio.Task] = {}
+
+    def start(self) -> None:
+        """Start listening for button events."""
+        self._unsub = self._hass.bus.async_listen(
+            EVENT_WIBUTLER_BUTTON, self._handle_event
+        )
+
+    def stop(self) -> None:
+        """Stop listening and cancel running tasks."""
+        if self._unsub:
+            self._unsub()
+            self._unsub = None
+        for task in self._active_tasks.values():
+            task.cancel()
+        self._active_tasks.clear()
+
+    async def _handle_event(self, event: Event) -> None:
+        """Dispatch button event to the correct handler."""
+        data = event.data
+        device_id = data.get("device_id")
+        button = data.get("button")
+        action = data.get("action")
+        _LOGGER.debug("Rocker event: %s %s %s", device_id, button, action)
+
+        for binding in self._bindings:
+            if binding["device_id"] != device_id or binding["button"] != button:
+                continue
+
+            entity_ids = binding.get(
+                "target_entity_ids",
+                [binding["target_entity_id"]] if "target_entity_id" in binding else [],
+            )
+            mode = binding["mode"]
+            task_key = f"{device_id}_{button}"
+
+            for entity_id in entity_ids:
+                if mode in ("dim_up", "dim_down"):
+                    await self._handle_dim(task_key, entity_id, mode, action)
+                elif mode in ("cover_open", "cover_close"):
+                    await self._handle_cover(task_key, entity_id, mode, action)
+                elif mode == "toggle":
+                    await self._handle_toggle(entity_id, action)
+                elif mode == "turn_off":
+                    await self._handle_service(entity_id, action, "turn_off")
+                elif mode == "turn_on":
+                    await self._handle_service(entity_id, action, "turn_on")
+
+    async def _handle_dim(
+        self, task_key: str, entity_id: str, mode: str, action: str
+    ) -> None:
+        """Handle dimming actions."""
+        _LOGGER.debug("Dim: %s %s %s %s", task_key, entity_id, mode, action)
+        if action == "short_press":
+            await self._hass.services.async_call(
+                "light", "toggle", {"entity_id": entity_id}
+            )
+        elif action == "long_press_start":
+            step = self._dim_step if mode == "dim_up" else -self._dim_step
+            _LOGGER.debug("Starting dim loop: %s step=%s", entity_id, step)
+            task = self._hass.async_create_task(
+                self._dim_loop(entity_id, step)
+            )
+            self._active_tasks[task_key] = task
+        elif action in ("release", "long_press_release"):
+            task = self._active_tasks.pop(task_key, None)
+            _LOGGER.debug("Stopping dim: task=%s", task)
+            if task:
+                task.cancel()
+
+    async def _dim_loop(self, entity_id: str, step: int) -> None:
+        """Repeatedly step brightness until cancelled."""
+        try:
+            while True:
+                state = self._hass.states.get(entity_id)
+                if state is None:
+                    _LOGGER.debug("Dim loop: entity %s not found", entity_id)
+                    break
+                current = state.attributes.get("brightness", 0) or 0
+                target = max(0, min(255, current + step))
+                _LOGGER.debug("Dim loop: %s current=%s target=%s step=%s", entity_id, current, target, step)
+                if target <= 0:
+                    await self._hass.services.async_call(
+                        "light", "turn_off", {"entity_id": entity_id}
+                    )
+                    break
+                await self._hass.services.async_call(
+                    "light",
+                    "turn_on",
+                    {"entity_id": entity_id, "brightness": target},
+                )
+                if target >= 255:
+                    break
+                await asyncio.sleep(DIM_INTERVAL)
+        except asyncio.CancelledError:
+            pass
+
+    async def _handle_cover(
+        self, task_key: str, entity_id: str, mode: str, action: str
+    ) -> None:
+        """Handle cover actions."""
+        if action == "short_press":
+            service = "open_cover" if mode == "cover_open" else "close_cover"
+            await self._hass.services.async_call(
+                "cover", service, {"entity_id": entity_id}
+            )
+        elif action == "long_press_start":
+            service = "open_cover" if mode == "cover_open" else "close_cover"
+            await self._hass.services.async_call(
+                "cover", service, {"entity_id": entity_id}
+            )
+        elif action in ("release", "long_press_release"):
+            await self._hass.services.async_call(
+                "cover", "stop_cover", {"entity_id": entity_id}
+            )
+
+    async def _handle_toggle(self, entity_id: str, action: str) -> None:
+        """Handle toggle on short press."""
+        if action == "short_press":
+            domain = entity_id.split(".")[0]
+            await self._hass.services.async_call(
+                domain, "toggle", {"entity_id": entity_id}
+            )
+
+    async def _handle_service(
+        self, entity_id: str, action: str, service: str
+    ) -> None:
+        """Handle turn_on/turn_off on short press."""
+        if action == "short_press":
+            domain = entity_id.split(".")[0]
+            await self._hass.services.async_call(
+                domain, service, {"entity_id": entity_id}
+            )

--- a/custom_components/wibutler/strings.json
+++ b/custom_components/wibutler/strings.json
@@ -1,0 +1,61 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "Wibutler Hub",
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "username": "Username",
+                    "password": "Password",
+                    "verify_ssl": "Verify SSL",
+                    "use_ssl": "Use SSL"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "Cannot connect to Wibutler hub",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unknown error"
+        },
+        "abort": {
+            "already_configured": "Device is already configured"
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Wibutler Options",
+                "data": {
+                    "next_step": "Section"
+                }
+            },
+            "connection": {
+                "title": "Connection Settings",
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "username": "Username",
+                    "password": "Password",
+                    "verify_ssl": "Verify SSL",
+                    "use_ssl": "Use SSL"
+                }
+            },
+            "rocker_menu": {
+                "title": "Rocker Bindings",
+                "data": {
+                    "dim_duration": "Dim duration (seconds, 0-100%)",
+                    "action": "Select action"
+                }
+            },
+            "add_binding": {
+                "title": "Add Rocker Binding",
+                "data": {
+                    "device_button": "Button",
+                    "target_entity_ids": "Target Entities",
+                    "mode": "Mode"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/wibutler/translations/de.json
+++ b/custom_components/wibutler/translations/de.json
@@ -1,0 +1,61 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "Wibutler Hub",
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "username": "Benutzername",
+                    "password": "Passwort",
+                    "verify_ssl": "SSL verifizieren",
+                    "use_ssl": "SSL verwenden"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "Verbindung zum Wibutler Hub nicht möglich",
+            "invalid_auth": "Ungültige Anmeldedaten",
+            "unknown": "Unbekannter Fehler"
+        },
+        "abort": {
+            "already_configured": "Gerät ist bereits konfiguriert"
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Wibutler Optionen",
+                "data": {
+                    "next_step": "Bereich"
+                }
+            },
+            "connection": {
+                "title": "Verbindungseinstellungen",
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "username": "Benutzername",
+                    "password": "Passwort",
+                    "verify_ssl": "SSL verifizieren",
+                    "use_ssl": "SSL verwenden"
+                }
+            },
+            "rocker_menu": {
+                "title": "Wippen-Zuordnungen",
+                "data": {
+                    "dim_duration": "Dimm-Dauer (Sekunden, 0-100%)",
+                    "action": "Aktion auswählen"
+                }
+            },
+            "add_binding": {
+                "title": "Wippen-Zuordnung hinzufügen",
+                "data": {
+                    "device_button": "Taste",
+                    "target_entity_ids": "Ziel-Entitäten",
+                    "mode": "Modus"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/wibutler/translations/en.json
+++ b/custom_components/wibutler/translations/en.json
@@ -1,0 +1,61 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "Wibutler Hub",
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "username": "Username",
+                    "password": "Password",
+                    "verify_ssl": "Verify SSL",
+                    "use_ssl": "Use SSL"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "Cannot connect to Wibutler hub",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unknown error"
+        },
+        "abort": {
+            "already_configured": "Device is already configured"
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Wibutler Options",
+                "data": {
+                    "next_step": "Section"
+                }
+            },
+            "connection": {
+                "title": "Connection Settings",
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "username": "Username",
+                    "password": "Password",
+                    "verify_ssl": "Verify SSL",
+                    "use_ssl": "Use SSL"
+                }
+            },
+            "rocker_menu": {
+                "title": "Rocker Bindings",
+                "data": {
+                    "dim_duration": "Dim duration (seconds, 0-100%)",
+                    "action": "Select action"
+                }
+            },
+            "add_binding": {
+                "title": "Add Rocker Binding",
+                "data": {
+                    "device_button": "Button",
+                    "target_entity_ids": "Target Entities",
+                    "mode": "Mode"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Fire wibutler_button events (press, release, short_press, long_press_start, long_press_release) from binary sensors with 400ms threshold
- Add RockerController that consumes button events and controls lights/covers
- Support modes: dim_up, dim_down, cover_open, cover_close, toggle, turn_on, turn_off
- Multi-entity bindings per button
- Configurable dim duration (default 5s for 0-100%)
- Options flow with rocker binding management (add/remove)
- German and English translations